### PR TITLE
pyjwt 2.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "PyJWT" %}
-{% set version = "2.1.0" %}
+{% set version = "2.4.0" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash = "fba44e7898bbca160a2b2b501f492824fc8382485d3a6f11ba5d0c1937ce6130" %}
+{% set hash = "d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba" %}
 
 
 package:
@@ -19,16 +19,15 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
 
 requirements:
-  build:
-    - python
   host:
     - python
     - pip
-
+    - setuptools
+    - wheel
   run:
     - python
   run_constrained:
-    - cryptography >=3.3.1,<4.0.0
+    - cryptography >=3.3.1
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
 
 requirements:
@@ -42,7 +43,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'JSON Web Token implementation in Python'
+  summary: JSON Web Token implementation in Python
   dev_url: https://github.com/jpadilla/pyjwt
   doc_url: https://pyjwt.readthedocs.io/en/latest/
 

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,9 @@
+import jwt
+
+
+key = "secret"
+encoded = jwt.encode({"some": "payload"}, key, algorithm="HS256")
+
+assert encoded == 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzb21lIjoicGF5bG9hZCJ9.Joh1R2dYzkRvDkqv3sygm5YyK8Gi4ShZqbhK2gxcs2U'
+
+assert jwt.decode(encoded, key, algorithms="HS256") == {'some': 'payload'}


### PR DESCRIPTION
Update to 2.4.0 to fix CVE-2022-29217

Changelog: https://github.com/jpadilla/pyjwt/blob/2.4.0/CHANGELOG.rst
License: https://github.com/jpadilla/pyjwt/blob/2.4.0/LICENSE
Requirements:
- https://github.com/jpadilla/pyjwt/blob/2.4.0/pyproject.toml
- https://github.com/jpadilla/pyjwt/blob/2.4.0/setup.cfg

The package pyjwt is mentioned inside the packages:
adal | flask-appbuilder | flask-jwt-extended | oauthlib | pygithub | snowflake-connector-python |

Actions:
1. Skip py<36
2. Remove req/build
3. Add missing packages
4. Add run_test.py 
5. Update pinning: cryptography >=3.3.1