### PR TITLE
pyjwt 2.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,18 @@
 {% set name = "PyJWT" %}
-{% set version = "2.4.0" %}
-{% set bundle = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash = "d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba" %}
-
+{% set version = "2.8.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  {{ hash_type }}: {{ hash }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de
 
 build:
   number: 0
-  skip: True  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
@@ -28,15 +23,19 @@ requirements:
   run:
     - python
   run_constrained:
-    - cryptography >=3.3.1
+    - cryptography >=3.4.0
 
 test:
-  requires:
-    - pip
+  source_files:
+    - tests
   imports:
     - jwt
+  requires:
+    - pip
+    - pytest >=6.0.0,<7.0.0
   commands:
     - pip check
+    - pytest tests
 
 about:
   home: https://github.com/jpadilla/pyjwt
@@ -44,8 +43,11 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: JSON Web Token implementation in Python
+  description: |
+    PyJWT is a Python library which allows you to encode and decode JSON Web Tokens (JWT). 
+    JWT is an open, industry-standard (RFC 7519) for representing claims securely between two parties.
   dev_url: https://github.com/jpadilla/pyjwt
-  doc_url: https://pyjwt.readthedocs.io/en/latest/
+  doc_url: https://pyjwt.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - wheel
   run:
     - python
+    - typing_extensions # [py<=37]
   run_constrained:
     - cryptography >=3.4.0
 

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,9 +1,9 @@
 import jwt
 
+# See an example https://pyjwt.readthedocs.io/en/latest/usage.html#encoding-decoding-tokens-with-hs256
+KEY = "secret"
+encoded = jwt.encode({"some": "payload"}, KEY, algorithm="HS256")
 
-key = "secret"
-encoded = jwt.encode({"some": "payload"}, key, algorithm="HS256")
+assert encoded == 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg'
 
-assert encoded == 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzb21lIjoicGF5bG9hZCJ9.Joh1R2dYzkRvDkqv3sygm5YyK8Gi4ShZqbhK2gxcs2U'
-
-assert jwt.decode(encoded, key, algorithms="HS256") == {'some': 'payload'}
+assert jwt.decode(encoded, KEY, algorithms="HS256") == {'some': 'payload'}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4194](https://anaconda.atlassian.net/browse/PKG-4194)
- changelog: https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.rst
- license: https://github.com/jpadilla/pyjwt/blob/master/LICENSE
- requirements-tagged:
  - https://github.com/jpadilla/pyjwt/blob/2.8.0/pyproject.toml
  - https://github.com/jpadilla/pyjwt/blob/2.8.0/setup.cfg
  - https://github.com/jpadilla/pyjwt/blob/2.8.0/setup.py


### Explanation of changes:

- Cleaning up the recipe
- Skip `py<37`
- Update `cryptography`'s pinning
- Add tests
- Update `run_test.py` by using the latest [example](https://pyjwt.readthedocs.io/en/latest/usage.html#encoding-decoding-tokens-with-hs256)



[PKG-4194]: https://anaconda.atlassian.net/browse/PKG-4194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ