### PR TITLE
Pyjwt Update 2.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyjwt" %}
-{% set version = "2.9.0" %}
+{% set version = "2.10.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c
+  sha256: 3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953
 
 build:
   number: 0
-  skip: true  # [py<38]
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -44,7 +44,7 @@ about:
   license_file: LICENSE
   summary: JSON Web Token implementation in Python
   description: |
-    PyJWT is a Python library which allows you to encode and decode JSON Web Tokens (JWT). 
+    PyJWT is a Python library which allows you to encode and decode JSON Web Tokens (JWT).
     JWT is an open, industry-standard (RFC 7519) for representing claims securely between two parties.
   dev_url: https://github.com/jpadilla/pyjwt
   doc_url: https://pyjwt.readthedocs.io


### PR DESCRIPTION
> ## ☆Pyjwt Update 2.10.1☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6428) 
[Upstream](https://github.com/jpadilla/pyjwt)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Skip for Python versions less than 3.9